### PR TITLE
feat: Support unindexed-keys

### DIFF
--- a/rugged/unflatteners.py
+++ b/rugged/unflatteners.py
@@ -1,8 +1,7 @@
+from collections.abc import Mapping
 import re
-from typing import Any
+from typing import Any, Iterable
 
-
-prefix_pattern = re.compile(r"^([^\[]+)")
 key_pattern = re.compile(r"\[([^\]]*)\]")
 
 
@@ -12,7 +11,7 @@ def parse_key(key: str) -> tuple[str | None, list[str | None]]:
 
     For example, results[0][name] will return 'results', ['0', 'name']
 
-    No bracket pairs will be returned as an empty list.
+    When no bracket pairs are present, an empty list is returned.
 
     Empty square brackets, to represent auto-numbering of list indices, are represented as None
 
@@ -20,64 +19,214 @@ def parse_key(key: str) -> tuple[str | None, list[str | None]]:
 
     """
 
-    prefix_match = prefix_pattern.match(key)
-    prefix = None if prefix_match is None else prefix_match.group(0)
-
     key_pairs = key_pattern.findall(key)
+
+    # If there was a matched key, use the text before as the prefix
+    prefix = key
+    if len(key_pairs) > 0:
+        prefix = key.split(f"[{key_pairs[0]}]", 1)[0]
+    prefix = prefix if len(prefix) > 0 else None
+
     return prefix, [sub_key if len(sub_key) > 0 else None for sub_key in key_pairs]
 
 
 def unflatten(data: dict[str, Any]) -> dict[str, Any] | list[Any]:
-    nested = {}
+    """
+    Unflatten a flat dictionary into a nested dictionary
 
-    # Iterate over flat keys
+    The input dictionary is expected to be as received by a HTTP client. i.e.:
+    - Ordered
+    - Flat
+    - Duplicate keys as one key with a list of values
+
+    We follow these rules:
+
+    1. Keys without square brackets are returned straightforwardly:
+
+    => { "action": "signup", "email": "foo@example.com" }
+    <= { "action": "signup", "email": "foo@example.com" }
+
+    2. Keys with named square brackets are treated as objects:
+
+    => { "address[zipcode]": "90210" }
+    <= { "address": { "zipcode": "90210" } }
+
+    3. Keys with postfix empty square brackets are treated as lists:
+
+    => { "emails[]": ["foo@example.com", "bar@example.com"] }
+    <= { "emails": ["foo@example.com", "bar@example.com"] }
+
+    4. Keys with prefix empty square brackets are treated as lists of objects:
+
+    => { "users[][id]": [1, 2], "users[][name]": ["foo", "bar"] }
+    <= { "users": [{ "id": 1, "name": "foo" }, { "id": 2, "name": "bar" }] }
+
+    5. TODO: Currently, keys with numbered square brackets are treated as rule 2, but will be treated more like rule 4 in future.
+
+    6. Any keys that do not conform to these rules are returned as-is.
+
+    For clarity, in this function we use the following terminology:
+    - the "root key" is the key before the first square bracket
+    - "indexes" are the values inside the square brackets
+        - A None index is used as a marker for a list
+    - a "path" is an address to a nested value, including the root key and indexes, e.g. users[][name] => ("users", None, "name")
+
+    """
+
+    # The nested dictionary we're building
+    nested: dict[str, Any] = {}
+
+    # A list of paths
+    list_paths: list[tuple[str]] = []
+
     for key, value in data.items():
-        # Find keys with complete square brackets in
-        root_key, sub_keys = parse_key(key)
-        # Skip if no sub-keys
-        if len(sub_keys) == 0:
+        # Get the root key (before square brackets) and indices
+        root_key, indexes = parse_key(key)
+
+        # Return invalid keys like `[address][postcode]` as-is
+        if root_key is None:
             nested[key] = value
             continue
 
-        # Get root key - root_key[sub_key]
-        if not root_key:
-            # If root key is empty, return the whole key as-is
-            # TODO: Raise a warning
-            nested[key] = value
+        # root is used as a reference to the part of the nested dictionary we're building
+        root = nested
+        # Marks when we have replaced root with a list
+        root_is_list = False
+
+        # Simple key => value items
+        if len(indexes) == 0:
+            root[root_key] = value
             continue
 
-        if root_key not in nested:
-            nested[root_key] = {}
+        # Set root
+        if root_key not in root:
+            root[root_key] = {}
 
-        # Build nesting structure
-        root = nested[root_key]
-        for idx, sub_key in enumerate(sub_keys):
-            if sub_key not in root:
-                root[sub_key] = {}
+        # parent is used to replace a root with a list later on
+        parent = root
+        root = root[root_key]
 
-            # If last sub-key, set value
-            if idx == len(sub_keys) - 1:
-                root[sub_key] = value
-                break
+        for idx, index in enumerate(indexes):
+            # Setup some contextual vars
+            prev_idx = indexes[idx - 1] if idx > 0 else root_key
+            is_last = idx == len(indexes) - 1
+            path = (root_key, *indexes[: idx + 1])
+            is_list = index is None
 
-            # Set new level root
-            root = root[sub_key]
+            # Empty-square-bracket cases, item[] => value
+            if is_list:
+                # Replace previous item with a list
+                # TODO: If root was set to a value/map earlier, this will overwrite root. Unsure how to handle - error?
+                if not isinstance(root, list):
+                    root = parent
+                    root[prev_idx] = []
+                    # Capture path for restructuring later
+                    list_paths.append(path[:-1])
 
-    # Re-process keys, if all are numeric and sequential 0..n, convert to list
-    return sequential_numeric_keys_to_lists(nested)
+                # Don't change parent as we've replaced it
+                root = parent[prev_idx]
+                root_is_list = True
+
+                # Handle root_key[...][] = value
+                if is_last:
+                    root.extend(value) if isinstance(value, list) else root.append(
+                        value
+                    )
+
+                continue
+
+            # Named square-bracket cases, item[...][key] => value
+            if root_is_list and is_last:
+                # Create mapping to append to list
+                obj = {}
+
+                # Wrap item in a list here, for consistency when restructuring
+                if not isinstance(value, list):
+                    value = [value]
+
+                obj[index] = value
+                root.append(obj)
+
+                continue
+
+            # Create a new map
+            if index not in root:
+                root[index] = {}
+
+            # Use the map going forward
+            if not is_last:
+                parent = root
+                root = root[index]
+                continue
+
+            # Set the map value, item[key] = value
+            root[index] = value
+
+    # Restructure lists of objects into multiple objects
+    for path in list_paths:
+        # Get the list of objects from the nested dictionary
+        target: list[dict] | dict = nested
+        # Container is the object that contains this list, and the key it is set to
+        # TODO: This probably doesn't work with root[][][key] paths (but should it?)
+        container = None
+        container_key = None
+        for idx, part in enumerate(path):
+            # Capture container
+            if idx == len(path) - 1:
+                container = target
+                container_key = part
+            target = target[part]
+
+        # Restructure the list into a list of objects
+        container[container_key] = restructure_list(target)
+
+    return nested
 
 
-def sequential_numeric_keys_to_lists(
-    data: dict[str, Any],
-) -> dict[str, Any] | list[Any]:
-    if isinstance(data, dict):
-        # Check if all keys are sequential numeric
-        keys = sorted(data.keys())
-        if keys == list(map(str, range(len(keys)))):
-            # Restructure to list
-            return [sequential_numeric_keys_to_lists(data[key]) for key in keys]
-        else:
-            # Process nested dicts
-            return {key: sequential_numeric_keys_to_lists(data[key]) for key in data}
-    else:
-        return data
+def restructure_list(target: list[Any]) -> list[dict[str, Any]]:
+    # If this is a list of scalar values, we don't need to restructure
+    if not all(isinstance(obj, Mapping) for obj in target):
+        return target
+
+    # Each obj in target will be an map with one key and a list of values
+
+    # Compose each obj into a single map
+    # Duplicates are supported, but shouldn't be common
+    key_values = {}
+    for obj in target:
+        for key, value in obj.items():
+            if key not in key_values:
+                key_values[key] = []
+            key_values[key].extend(value)
+
+    # Sanity check that all lists are the same length
+    # TODO: Raise error?
+    assert all_equal(
+        [len(values) for values in key_values.values()]
+    ), "objects in list have mismatching item counts"
+
+    # Get the number of resulting objects
+    item_count = len(list(key_values.values())[0])
+
+    # Create a new object with its associated keys
+    objs = []
+    for idx in range(item_count):
+        obj = {}
+        for key, values in key_values.items():
+            obj[key] = values[idx]
+        objs.append(obj)
+
+    return objs
+
+
+def all_equal(items: Iterable) -> bool:
+    val = None
+    for item in items:
+        if val is None:
+            val = item
+            continue
+
+        if val != item:
+            return False
+
+    return True

--- a/rugged/unflatteners.py
+++ b/rugged/unflatteners.py
@@ -2,41 +2,66 @@ import re
 from typing import Any
 
 
+prefix_pattern = re.compile(r"^([^\[]+)")
+key_pattern = re.compile(r"\[([^\]]*)\]")
+
+
+def parse_key(key: str) -> tuple[str | None, list[str | None]]:
+    """
+    Finds paired square brackets in a key, and returns the inner values
+
+    For example, results[0][name] will return 'results', ['0', 'name']
+
+    No bracket pairs will be returned as an empty list.
+
+    Empty square brackets, to represent auto-numbering of list indices, are represented as None
+
+    When no root key is given (e.g. [0][name]), the root key will be None.
+
+    """
+
+    prefix_match = prefix_pattern.match(key)
+    prefix = None if prefix_match is None else prefix_match.group(0)
+
+    key_pairs = key_pattern.findall(key)
+    return prefix, [sub_key if len(sub_key) > 0 else None for sub_key in key_pairs]
+
+
 def unflatten(data: dict[str, Any]) -> dict[str, Any] | list[Any]:
     nested = {}
 
     # Iterate over flat keys
     for key, value in data.items():
         # Find keys with complete square brackets in
-        sub_keys = re.findall(r"\[([^\]]+)\]", key)
+        root_key, sub_keys = parse_key(key)
         # Skip if no sub-keys
         if len(sub_keys) == 0:
             nested[key] = value
             continue
 
         # Get root key - root_key[sub_key]
-        root_key = re.match(r"^([^\[]+)", key)
-        if not root_key or not root_key.group(0) or len(root_key.group(0)) == 0:
+        if not root_key:
+            # If root key is empty, return the whole key as-is
             # TODO: Raise a warning
             nested[key] = value
             continue
 
-        if root_key.group(0) not in nested:
-            nested[root_key.group(0)] = {}
+        if root_key not in nested:
+            nested[root_key] = {}
 
         # Build nesting structure
-        root = nested[root_key.group(0)]
-        for idx, key in enumerate(sub_keys):
-            if key not in root:
-                root[key] = {}
+        root = nested[root_key]
+        for idx, sub_key in enumerate(sub_keys):
+            if sub_key not in root:
+                root[sub_key] = {}
 
             # If last sub-key, set value
             if idx == len(sub_keys) - 1:
-                root[key] = value
+                root[sub_key] = value
                 break
 
             # Set new level root
-            root = root[key]
+            root = root[sub_key]
 
     # Re-process keys, if all are numeric and sequential 0..n, convert to list
     return sequential_numeric_keys_to_lists(nested)

--- a/tests/test_bracket_matching.py
+++ b/tests/test_bracket_matching.py
@@ -1,0 +1,11 @@
+from rugged.unflatteners import parse_key
+
+
+def test_find_square_bracket_pairs() -> None:
+    assert parse_key("contacts[name]") == ("contacts", ["name"])
+    assert parse_key("results[0][name]") == ("results", ["0", "name"])
+    assert parse_key("created_at") == ("created_at", [])
+
+
+def test_find_empty_square_bracket_pairs() -> None:
+    assert parse_key("contacts[]") == ("contacts", [None])

--- a/tests/test_bracket_matching.py
+++ b/tests/test_bracket_matching.py
@@ -9,3 +9,9 @@ def test_find_square_bracket_pairs() -> None:
 
 def test_find_empty_square_bracket_pairs() -> None:
     assert parse_key("contacts[]") == ("contacts", [None])
+
+
+def test_broken_brackets() -> None:
+    assert parse_key("address[road") == ("address[road", [])
+    assert parse_key("address]city[") == ("address]city[", [])
+    assert parse_key("[address][postcode]") == (None, ["address", "postcode"])

--- a/tests/test_middleware_fastapi.py
+++ b/tests/test_middleware_fastapi.py
@@ -21,9 +21,7 @@ def test_fastapi_usage() -> None:
     response = client.post(
         "/invite",
         json={
-            "emails[0]": "foo@example.com",
-            "emails[1]": "bar@example.com",
-            "emails[2]": "baz@example.com",
+            "emails[]": ["foo@example.com", "bar@example.com", "baz@example.com"],
         },
     )
 

--- a/tests/test_middleware_starlette.py
+++ b/tests/test_middleware_starlette.py
@@ -24,9 +24,7 @@ def test_starlette_usage() -> None:
     response = client.post(
         "/invite",
         json={
-            "emails[0]": "foo@example.com",
-            "emails[1]": "bar@example.com",
-            "emails[2]": "baz@example.com",
+            "emails[]": ["foo@example.com", "bar@example.com", "baz@example.com"],
         },
     )
 

--- a/tests/test_unflatteners.py
+++ b/tests/test_unflatteners.py
@@ -142,7 +142,7 @@ def test_unflattening_single_list_item_deep_structure() -> None:
         "recipients[][name][family_name]": "Masters",
     }
 
-    assert unflatten(d) == {  # type: ignore[arg-type]
+    assert unflatten(d) == {
         "recipients": [
             {
                 "name": {
@@ -194,7 +194,7 @@ def test_unflattening_multi_list_item_deep_structure() -> None:
     }
 
 
-def test_sequential_ints_treated_as_named_brackets():
+def test_sequential_ints_treated_as_named_brackets() -> None:
     d = {
         "users[0][name]": "Foo",
         "users[0][email]": "foo@example.com",
@@ -223,7 +223,7 @@ def test_sequential_ints_treated_as_named_brackets():
 
 
 @pytest.mark.xfail(reason="Future intention, not yet supported")
-def test_sequential_ints_treated_as_lists():
+def test_sequential_ints_treated_as_lists() -> None:
     d = {
         "users[0][name]": "Foo",
         "users[0][email]": "foo@example.com",
@@ -251,7 +251,7 @@ def test_sequential_ints_treated_as_lists():
     }
 
 
-def test_non_sequential_ints_treated_as_named_brackets():
+def test_non_sequential_ints_treated_as_named_brackets() -> None:
     d = {
         "users[3][name]": "Foo",
         "users[3][email]": "foo@example.com",

--- a/tests/test_unflatteners.py
+++ b/tests/test_unflatteners.py
@@ -17,24 +17,6 @@ def test_unflatten_flat_dict() -> None:
     assert unflatten(d) == d
 
 
-def test_unflatten_nested_dict() -> None:
-    d = {
-        "user_id": uuid4(),
-        "comments": [
-            {
-                "comment_id": uuid4(),
-                "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-            },
-            {
-                "comment_id": uuid4(),
-                "message": "Aliquam vel ex ac erat feugiat bibendum varius eu ipsum.",
-            },
-        ],
-    }
-
-    assert unflatten(d) == d
-
-
 def test_unflatten_single_level_nesting() -> None:
     d = {
         "email": "ross@example.com",
@@ -95,28 +77,39 @@ def test_unflatten_deep_nesting() -> None:
     }
 
 
-def test_unflattening_with_sequential_ints() -> None:
+def test_unflattening_simple_list() -> None:
     d = {
-        "attendees[0]": "ross@example.com",
-        "attendees[1]": "roos@example.com",
-        "attendees[2]": "mr.snrub@example.com",
+        "emails[]": ["ross@example.com", "yolo@example.com"],
+    }
+
+    assert unflatten(d) == {
+        "emails": [
+            "ross@example.com",
+            "yolo@example.com",
+        ]
+    }
+
+
+def test_unflattening_single_list_item_flat_structure() -> None:
+    d = {
+        "attendees[][name]": "Lyle Lanley",
+        "attendees[][email]": "onthemap@example.com",
     }
 
     assert unflatten(d) == {
         "attendees": [
-            "ross@example.com",
-            "roos@example.com",
-            "mr.snrub@example.com",
+            {
+                "name": "Lyle Lanley",
+                "email": "onthemap@example.com",
+            },
         ],
     }
 
 
-def test_unflattening_list_of_dicts() -> None:
+def test_unflattening_multi_list_item_flat_structure() -> None:
     d = {
-        "attendees[0][name]": "Lyle Lanley",
-        "attendees[0][email]": "onthemap@example.com",
-        "attendees[1][name]": "Mr Snrub",
-        "attendees[1][email]": "spp@example.com",
+        "attendees[][name]": ["Lyle Lanley", "Mr Snrub"],
+        "attendees[][email]": ["onthemap@example.com", "spp@example.com"],
     }
 
     assert unflatten(d) == {
@@ -133,32 +126,154 @@ def test_unflattening_list_of_dicts() -> None:
     }
 
 
-def test_unflattening_mix_keys_and_integer_list() -> None:
+@pytest.mark.xfail(reason="Requires further refactoring")
+def test_unflattening_single_list_item_deep_structure() -> None:
+    """
+    Example HTML for this case:
+        <input name="recipients[][name][title]" value="Mr">
+        <input name="recipients[][name][given_name]" value="Ross">
+        <input name="recipients[][name][family_name]" value="Masters">
+
+    """
+
     d = {
-        "attendees[0]": "Ross",
-        "attendees[one]": "Homer",
+        "recipients[][name][title]": "Mr",
+        "recipients[][name][given_name]": "Ross",
+        "recipients[][name][family_name]": "Masters",
+    }
+
+    assert unflatten(d) == {  # type: ignore[arg-type]
+        "recipients": [
+            {
+                "name": {
+                    "title": "Mr",
+                    "given_name": "Ross",
+                    "family_name": "Masters",
+                },
+            },
+        ],
+    }
+
+
+@pytest.mark.xfail(reason="Requires further refactoring")
+def test_unflattening_multi_list_item_deep_structure() -> None:
+    """
+    Example HTML for this case:
+        <input name="residents[][name][title]" value="Mr">
+        <input name="residents[][name][given_name]" value="Homer">
+        <input name="residents[][name][family_name]" value="Simpson">
+        <input name="residents[][name][title]" value="Mrs">
+        <input name="residents[][name][given_name]" value="Marge">
+        <input name="residents[][name][family_name]" value="Simpson">
+
+    """
+
+    d = {
+        "residents[][name][title]": ["Mr", "Mrs"],
+        "residents[][name][given_name]": ["Homer", "Marge"],
+        "residents[][name][family_name]": ["Simpson", "Simpson"],
     }
 
     assert unflatten(d) == {
-        "attendees": {
-            "0": "Ross",
-            "one": "Homer",
+        "residents": [
+            {
+                "name": {
+                    "title": "Mr",
+                    "given_name": "Homer",
+                    "family_name": "Simpson",
+                },
+            },
+            {
+                "name": {
+                    "title": "Mrs",
+                    "given_name": "Marge",
+                    "family_name": "Simpson",
+                },
+            },
+        ],
+    }
+
+
+def test_sequential_ints_treated_as_named_brackets():
+    d = {
+        "users[0][name]": "Foo",
+        "users[0][email]": "foo@example.com",
+        "users[1][name]": "Bar",
+        "users[1][email]": "bar@example.com",
+        "users[2][name]": "Baz",
+        "users[2][email]": "baz@example.com",
+    }
+
+    assert unflatten(d) == {
+        "users": {
+            "0": {
+                "name": "Foo",
+                "email": "foo@example.com",
+            },
+            "1": {
+                "name": "Bar",
+                "email": "bar@example.com",
+            },
+            "2": {
+                "name": "Baz",
+                "email": "baz@example.com",
+            },
         }
     }
 
 
-@pytest.mark.xfail(reason="Not yet implemented")
-def test_unflattening_list_with_empty_keys() -> None:
-    d = [
-        ("products[]", "Fish Tacos"),
-        ("products[]", "Swan Soufle"),
-        ("products[]", "Crayon Croutons"),
-    ]
+@pytest.mark.xfail(reason="Future intention, not yet supported")
+def test_sequential_ints_treated_as_lists():
+    d = {
+        "users[0][name]": "Foo",
+        "users[0][email]": "foo@example.com",
+        "users[1][name]": "Bar",
+        "users[1][email]": "bar@example.com",
+        "users[2][name]": "Baz",
+        "users[2][email]": "baz@example.com",
+    }
 
-    assert unflatten(d) == {  # type: ignore[arg-type]
-        "products": [
-            "Fish Tacos",
-            "Swan Soufle",
-            "Crayon Croutons",
-        ],
+    assert unflatten(d) == {
+        "users": [
+            {
+                "name": "Foo",
+                "email": "foo@example.com",
+            },
+            {
+                "name": "Bar",
+                "email": "bar@example.com",
+            },
+            {
+                "name": "Baz",
+                "email": "baz@example.com",
+            },
+        ]
+    }
+
+
+def test_non_sequential_ints_treated_as_named_brackets():
+    d = {
+        "users[3][name]": "Foo",
+        "users[3][email]": "foo@example.com",
+        "users[12][name]": "Bar",
+        "users[12][email]": "bar@example.com",
+        "users[2][name]": "Baz",
+        "users[2][email]": "baz@example.com",
+    }
+
+    assert unflatten(d) == {
+        "users": {
+            "3": {
+                "name": "Foo",
+                "email": "foo@example.com",
+            },
+            "12": {
+                "name": "Bar",
+                "email": "bar@example.com",
+            },
+            "2": {
+                "name": "Baz",
+                "email": "baz@example.com",
+            },
+        }
     }

--- a/tests/test_unflatteners.py
+++ b/tests/test_unflatteners.py
@@ -194,35 +194,6 @@ def test_unflattening_multi_list_item_deep_structure() -> None:
     }
 
 
-def test_sequential_ints_treated_as_named_brackets() -> None:
-    d = {
-        "users[0][name]": "Foo",
-        "users[0][email]": "foo@example.com",
-        "users[1][name]": "Bar",
-        "users[1][email]": "bar@example.com",
-        "users[2][name]": "Baz",
-        "users[2][email]": "baz@example.com",
-    }
-
-    assert unflatten(d) == {
-        "users": {
-            "0": {
-                "name": "Foo",
-                "email": "foo@example.com",
-            },
-            "1": {
-                "name": "Bar",
-                "email": "bar@example.com",
-            },
-            "2": {
-                "name": "Baz",
-                "email": "baz@example.com",
-            },
-        }
-    }
-
-
-@pytest.mark.xfail(reason="Future intention, not yet supported")
 def test_sequential_ints_treated_as_lists() -> None:
     d = {
         "users[0][name]": "Foo",


### PR DESCRIPTION
Fixes #2 

- Corrected behaviour for HTTP clients to send duplicated keys as square brackets, which enables non-indexed brackets (`root[]`) to be used
- Clarified behaviour in doc string and tests (docs to come)
- Added support for empty square brackets, but ~removed conversion of 0-indexed square brackets to lists~ (brought these back).

This could probably be a "cleaner", recursive function, but I found that quite tricky to understand and debug.